### PR TITLE
Fix severity and failon clash, documentation updated

### DIFF
--- a/packages/sarif-to-comment/README.md
+++ b/packages/sarif-to-comment/README.md
@@ -28,8 +28,8 @@ Install with [npm](https://www.npmjs.com/):
       --action                      Authentication mode for the token, defaults to PAT, if set, switches to Github Action
       --ruleDetails                 Include full JSON rule details in the markdown, might be too big for Github's API, defaults to false
       --simple                      Simplify the output to only give findings grouped by rule, adds helpURI if present
-      --severity                    Filter issues by their severity level, warning, error, note, none (separated by commas)
-      --failon                      Throw an exit error code 1 if an issue with that level was detected, warning, error, note, none, or all, set flag for each
+      --severity                    Filter output issues by their severity level, warning, error, note, none (separated by commas)
+      --failon                      Throw an exit error code 1 if an issue with that level was detected, warning, error, note, none, or all, set flag for each, NOT affected by severity filtering
       --commentUrl                  Post to comment URL. e.g. https://github.com/owner/repo/issues/85
       --title                       Specify a comment title for the report, optional
       --no-suppressedResults        Don't include suppressed results, that are in SARIF suppressions

--- a/packages/sarif-to-comment/src/cli.ts
+++ b/packages/sarif-to-comment/src/cli.ts
@@ -19,8 +19,8 @@ export function run() {
       --action                      Authentication mode for the token, defaults to PAT, if set, switches to Github Action
       --ruleDetails                 Include rule details in the markdown, might be too big for Github's API, defaults to false
       --simple                      Simplify the output to only give findings grouped by rule, adds helpURI if present
-      --severity                    Filter issues by their severity level, warning, error, note, none, set flag for each level      
-      --failon                      Throw an exit error code 1 if an issue with that level was detected, warning, error, note, none, or all, set flag for each
+      --severity                    Filter output issues by their severity level, warning, error, note, none, set flag for each level      
+      --failon                      Throw an exit error code 1 if an issue with that level was detected, warning, error, note, none, or all, set flag for each, NOT affected by severity filtering
       --title                       Specify a comment title for the report, optional
       --no-suppressedResults        Don't include suppressed results, that are in SARIF suppressions
       --commentUrl                  Post to comment URL. e.g. https://github.com/owner/repo/issues/85

--- a/packages/sarif-to-markdown/src/sarif-to-markdown.ts
+++ b/packages/sarif-to-markdown/src/sarif-to-markdown.ts
@@ -230,8 +230,7 @@ export const sarifToMarkdown = (options: sarifFormatterOptions): ((sarifLog: Log
     const suppressedResultsFlag = options.suppressedResults !== undefined ? options.suppressedResults : true;
     const simpleMode = options.simple !== undefined ? options.simple : false;
     const severities = options.severities ?? ["warning", "error", "note", "none"];
-    const failOn = options.failOn ?? [""]; // if not set, don't fail for anything
-
+    const failOn = options.failOn ?? false; // if not set, don't fail for anything
     return (sarifLog: Log) => {
         return sarifLog.runs.map((run: any) => {
             const title = options.title ? `# ${options.title}\n` : "# Report";
@@ -244,7 +243,7 @@ export const sarifToMarkdown = (options: sarifFormatterOptions): ((sarifLog: Log
             const filteredResults = filterGroupedResultsBySeverity(groupedResults, severities, run);
             const groupedResultsMarkdown = createGroupedResultsMarkdown(filteredResults, run, options);
             const hasMessage = run.results && run.results.length > 0 && Object.keys(filteredResults).length > 0;
-            const shouldFail = failOn != null ? detectFailure(run.results, failOn, run) : false;
+            const shouldFail = failOn === false ? false : detectFailure(run.results, failOn, run);
 
             /* Results
             - rule id


### PR DESCRIPTION
Fixes https://github.com/security-alert/security-alert/issues/45
I have tested the cli fully locally, I updated the docs and cli help because --severity only filters the comment output, it will not affect the failing mode (that way it can be flexible I guess, you can output all issues, but fail only on the highest severity, which is useful)