### PR TITLE
Make use of result error as it takes precedence over the rule

### DIFF
--- a/packages/sarif-to-markdown/test/snapshots/tfsec-report/input.json
+++ b/packages/sarif-to-markdown/test/snapshots/tfsec-report/input.json
@@ -1,0 +1,431 @@
+{
+    "version": "2.1.0",
+    "$schema": "https://json.schemastore.org/sarif-2.1.0-rtm.5.json",
+    "runs": [
+      {
+        "tool": {
+          "driver": {
+            "informationUri": "https://tfsec.dev",
+            "name": "tfsec",
+            "rules": [
+  {
+    "id": "aws-cloudwatch-log-group-customer-key",
+    "shortDescription": {
+      "text": "CloudWatch log groups should be encrypted using CMK"
+    },
+    "helpUri": "https://aquasecurity.github.io/tfsec/v1.26.3/checks/aws/cloudwatch/log-group-customer-key/"
+  },
+              {
+                "id": "aws-ec2-enable-at-rest-encryption",
+                "shortDescription": {
+                  "text": "Instance with unencrypted block device."
+                },
+                "helpUri": "https://aquasecurity.github.io/tfsec/v1.26.3/checks/aws/ec2/enable-at-rest-encryption/"
+              },
+              {
+                "id": "aws-ec2-enforce-http-token-imds",
+                "shortDescription": {
+                  "text": "aws_instance should activate session tokens for Instance Metadata Service."
+                },
+                "helpUri": "https://aquasecurity.github.io/tfsec/v1.26.3/checks/aws/ec2/enforce-http-token-imds/"
+              },
+              {
+                "id": "aws-ecs-enable-container-insight",
+                "shortDescription": {
+                  "text": "ECS clusters should have container insights enabled"
+                },
+                "helpUri": "https://aquasecurity.github.io/tfsec/v1.26.3/checks/aws/ecs/enable-container-insight/"
+              },
+              {
+                "id": "aws-iam-no-policy-wildcards",
+                "shortDescription": {
+                  "text": "IAM policy should avoid use of wildcards and instead apply the principle of least privilege"
+                },
+                "helpUri": "https://aquasecurity.github.io/tfsec/v1.26.3/checks/aws/iam/no-policy-wildcards/"
+              },
+              {
+                "id": "aws-s3-block-public-acls",
+                "shortDescription": {
+                  "text": "S3 Access block should block public ACL"
+                },
+                "helpUri": "https://aquasecurity.github.io/tfsec/v1.26.3/checks/aws/s3/block-public-acls/"
+              },
+              {
+                "id": "aws-s3-block-public-policy",
+                "shortDescription": {
+                  "text": "S3 Access block should block public policy"
+                },
+                "helpUri": "https://aquasecurity.github.io/tfsec/v1.26.3/checks/aws/s3/block-public-policy/"
+              },
+              {
+                "id": "aws-s3-enable-bucket-logging",
+                "shortDescription": {
+                  "text": "S3 Bucket does not have logging enabled."
+                },
+                "helpUri": "https://aquasecurity.github.io/tfsec/v1.26.3/checks/aws/s3/enable-bucket-logging/"
+              },
+              {
+                "id": "aws-s3-encryption-customer-key",
+                "shortDescription": {
+                  "text": "S3 encryption should use Customer Managed Keys"
+                },
+                "helpUri": "https://aquasecurity.github.io/tfsec/v1.26.3/checks/aws/s3/encryption-customer-key/"
+              },
+              {
+                "id": "aws-s3-ignore-public-acls",
+                "shortDescription": {
+                  "text": "S3 Access Block should Ignore Public Acl"
+                },
+                "helpUri": "https://aquasecurity.github.io/tfsec/v1.26.3/checks/aws/s3/ignore-public-acls/"
+              },
+              {
+                "id": "aws-s3-no-public-buckets",
+                "shortDescription": {
+                  "text": "S3 Access block should restrict public bucket to limit access"
+                },
+                "helpUri": "https://aquasecurity.github.io/tfsec/v1.26.3/checks/aws/s3/no-public-buckets/"
+              },
+              {
+                "id": "aws-s3-specify-public-access-block",
+                "shortDescription": {
+                  "text": "S3 buckets should each define an aws_s3_bucket_public_access_block"
+                },
+                "helpUri": "https://aquasecurity.github.io/tfsec/v1.26.3/checks/aws/s3/specify-public-access-block/"
+              },
+              {
+                "id": "aws-vpc-no-public-egress-sgr",
+                "shortDescription": {
+                  "text": "An egress security group rule allows traffic to /0."
+                },
+                "helpUri": "https://aquasecurity.github.io/tfsec/v1.26.3/checks/aws/vpc/no-public-egress-sgr/"
+              },
+              {
+                "id": "aws-vpc-no-public-ingress-sgr",
+                "shortDescription": {
+                  "text": "An ingress security group rule allows traffic from /0."
+                },
+                "helpUri": "https://aquasecurity.github.io/tfsec/v1.26.3/checks/aws/vpc/no-public-ingress-sgr/"
+              }
+            ]
+          }
+        },
+        "results": [
+          {
+            "ruleId": "aws-cloudwatch-log-group-customer-key",
+            "ruleIndex": 0,
+            "level": "note",
+            "message": {
+              "text": "Log group is not encrypted."
+            },
+            "locations": [
+              {
+                "physicalLocation": {
+                  "artifactLocation": {
+                    "uri": "lm-cloudwatch-group.tf"
+                  },
+                  "region": {
+                    "startLine": 1,
+                    "endLine": 5
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "ruleId": "aws-ec2-enable-at-rest-encryption",
+            "ruleIndex": 1,
+            "level": "error",
+            "message": {
+              "text": "Root block device is not encrypted."
+            },
+            "locations": [
+              {
+                "physicalLocation": {
+                  "artifactLocation": {
+                    "uri": "lm-prx-ec2.tf"
+                  },
+                  "region": {
+                    "startLine": 1,
+                    "endLine": 24
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "ruleId": "aws-ec2-enforce-http-token-imds",
+            "ruleIndex": 2,
+            "level": "error",
+            "message": {
+              "text": "Instance does not require IMDS access to require a token"
+            },
+            "locations": [
+              {
+                "physicalLocation": {
+                  "artifactLocation": {
+                    "uri": "lm-prx-ec2.tf"
+                  },
+                  "region": {
+                    "startLine": 1,
+                    "endLine": 24
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "ruleId": "aws-ecs-enable-container-insight",
+            "ruleIndex": 3,
+            "level": "note",
+            "message": {
+              "text": "Cluster does not have container insights enabled."
+            },
+            "locations": [
+              {
+                "physicalLocation": {
+                  "artifactLocation": {
+                    "uri": "lm-prx-ecs.tf"
+                  },
+                  "region": {
+                    "startLine": 1,
+                    "endLine": 6
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "ruleId": "aws-iam-no-policy-wildcards",
+            "ruleIndex": 4,
+            "level": "error",
+            "message": {
+              "text": "IAM policy document uses sensitive action 'logs:CreateLogGroup' on wildcarded resource 'arn:aws:logs:*:*:*'"
+            },
+            "locations": [
+              {
+                "physicalLocation": {
+                  "artifactLocation": {
+                    "uri": "lm-prx-policy.tf"
+                  },
+                  "region": {
+                    "startLine": 9,
+                    "endLine": 9
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "ruleId": "aws-iam-no-policy-wildcards",
+            "ruleIndex": 4,
+            "level": "error",
+            "message": {
+              "text": "IAM policy document uses sensitive action 'logs:CreateLogGroup' on wildcarded resource 'arn:aws:logs:*:*:*'"
+            },
+            "locations": [
+              {
+                "physicalLocation": {
+                  "artifactLocation": {
+                    "uri": "lm-prx-policy.tf"
+                  },
+                  "region": {
+                    "startLine": 9,
+                    "endLine": 9
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "ruleId": "aws-s3-block-public-acls",
+            "ruleIndex": 5,
+            "level": "error",
+            "message": {
+              "text": "No public access block so not blocking public acls"
+            },
+            "locations": [
+              {
+                "physicalLocation": {
+                  "artifactLocation": {
+                    "uri": "lm-prx-vpc-flow-log-s3.tf"
+                  },
+                  "region": {
+                    "startLine": 1,
+                    "endLine": 10
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "ruleId": "aws-s3-block-public-policy",
+            "ruleIndex": 6,
+            "level": "error",
+            "message": {
+              "text": "No public access block so not blocking public policies"
+            },
+            "locations": [
+              {
+                "physicalLocation": {
+                  "artifactLocation": {
+                    "uri": "lm-prx-vpc-flow-log-s3.tf"
+                  },
+                  "region": {
+                    "startLine": 1,
+                    "endLine": 10
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "ruleId": "aws-s3-enable-bucket-logging",
+            "ruleIndex": 7,
+            "level": "warning",
+            "message": {
+              "text": "Bucket does not have logging enabled"
+            },
+            "locations": [
+              {
+                "physicalLocation": {
+                  "artifactLocation": {
+                    "uri": "lm-prx-vpc-flow-log-s3.tf"
+                  },
+                  "region": {
+                    "startLine": 1,
+                    "endLine": 10
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "ruleId": "aws-s3-encryption-customer-key",
+            "ruleIndex": 8,
+            "level": "error",
+            "message": {
+              "text": "Bucket does not encrypt data with a customer managed key."
+            },
+            "locations": [
+              {
+                "physicalLocation": {
+                  "artifactLocation": {
+                    "uri": "lm-prx-vpc-flow-log-s3.tf"
+                  },
+                  "region": {
+                    "startLine": 12,
+                    "endLine": 19
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "ruleId": "aws-s3-ignore-public-acls",
+            "ruleIndex": 9,
+            "level": "error",
+            "message": {
+              "text": "No public access block so not ignoring public acls"
+            },
+            "locations": [
+              {
+                "physicalLocation": {
+                  "artifactLocation": {
+                    "uri": "lm-prx-vpc-flow-log-s3.tf"
+                  },
+                  "region": {
+                    "startLine": 1,
+                    "endLine": 10
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "ruleId": "aws-s3-no-public-buckets",
+            "ruleIndex": 10,
+            "level": "error",
+            "message": {
+              "text": "No public access block so not restricting public buckets"
+            },
+            "locations": [
+              {
+                "physicalLocation": {
+                  "artifactLocation": {
+                    "uri": "lm-prx-vpc-flow-log-s3.tf"
+                  },
+                  "region": {
+                    "startLine": 1,
+                    "endLine": 10
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "ruleId": "aws-s3-specify-public-access-block",
+            "ruleIndex": 11,
+            "level": "note",
+            "message": {
+              "text": "Bucket does not have a corresponding public access block."
+            },
+            "locations": [
+              {
+                "physicalLocation": {
+                  "artifactLocation": {
+                    "uri": "lm-prx-vpc-flow-log-s3.tf"
+                  },
+                  "region": {
+                    "startLine": 1,
+                    "endLine": 10
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "ruleId": "aws-vpc-no-public-egress-sgr",
+            "ruleIndex": 12,
+            "level": "error",
+            "message": {
+              "text": "Security group rule allows egress to multiple public internet addresses."
+            },
+            "locations": [
+              {
+                "physicalLocation": {
+                  "artifactLocation": {
+                    "uri": "lm-prx-sg.tf"
+                  },
+                  "region": {
+                    "startLine": 34,
+                    "endLine": 34
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "ruleId": "aws-vpc-no-public-ingress-sgr",
+            "ruleIndex": 13,
+            "level": "error",
+            "message": {
+              "text": "Security group rule allows ingress from public internet."
+            },
+            "locations": [
+              {
+                "physicalLocation": {
+                  "artifactLocation": {
+                    "uri": "lm-prx-sg.tf"
+                  },
+                  "region": {
+                    "startLine": 18,
+                    "endLine": 18
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }

--- a/packages/sarif-to-markdown/test/snapshots/tfsec-report/output.md
+++ b/packages/sarif-to-markdown/test/snapshots/tfsec-report/output.md
@@ -1,0 +1,120 @@
+# Report
+## Results
+
+- **[NOTE]** **[aws-cloudwatch-log-group-customer-key]** [[HELP LINK](https://aquasecurity.github.io/tfsec/v1.26.3/checks/aws/cloudwatch/log-group-customer-key/)] `Log group is not encrypted.`
+    - https://github.com/owner/repo/blob/master/base/lm-cloudwatch-group.tf#L1-L5
+- **[ERROR]** **[aws-ec2-enable-at-rest-encryption]** [[HELP LINK](https://aquasecurity.github.io/tfsec/v1.26.3/checks/aws/ec2/enable-at-rest-encryption/)] `Root block device is not encrypted.`
+    - https://github.com/owner/repo/blob/master/base/lm-prx-ec2.tf#L1-L24
+- **[ERROR]** **[aws-ec2-enforce-http-token-imds]** [[HELP LINK](https://aquasecurity.github.io/tfsec/v1.26.3/checks/aws/ec2/enforce-http-token-imds/)] `Instance does not require IMDS access to require a token`
+    - https://github.com/owner/repo/blob/master/base/lm-prx-ec2.tf#L1-L24
+- **[NOTE]** **[aws-ecs-enable-container-insight]** [[HELP LINK](https://aquasecurity.github.io/tfsec/v1.26.3/checks/aws/ecs/enable-container-insight/)] `Cluster does not have container insights enabled.`
+    - https://github.com/owner/repo/blob/master/base/lm-prx-ecs.tf#L1-L6
+- **[ERROR]** **[aws-iam-no-policy-wildcards]** [[HELP LINK](https://aquasecurity.github.io/tfsec/v1.26.3/checks/aws/iam/no-policy-wildcards/)] `IAM policy document uses sensitive action 'logs:CreateLogGroup' on wildcarded resource 'arn:aws:logs:\*:\*:\*'`
+    - https://github.com/owner/repo/blob/master/base/lm-prx-policy.tf#L9-L9
+    - https://github.com/owner/repo/blob/master/base/lm-prx-policy.tf#L9-L9
+- **[ERROR]** **[aws-s3-block-public-acls]** [[HELP LINK](https://aquasecurity.github.io/tfsec/v1.26.3/checks/aws/s3/block-public-acls/)] `No public access block so not blocking public acls`
+    - https://github.com/owner/repo/blob/master/base/lm-prx-vpc-flow-log-s3.tf#L1-L10
+- **[ERROR]** **[aws-s3-block-public-policy]** [[HELP LINK](https://aquasecurity.github.io/tfsec/v1.26.3/checks/aws/s3/block-public-policy/)] `No public access block so not blocking public policies`
+    - https://github.com/owner/repo/blob/master/base/lm-prx-vpc-flow-log-s3.tf#L1-L10
+- **[WARNING]** **[aws-s3-enable-bucket-logging]** [[HELP LINK](https://aquasecurity.github.io/tfsec/v1.26.3/checks/aws/s3/enable-bucket-logging/)] `Bucket does not have logging enabled`
+    - https://github.com/owner/repo/blob/master/base/lm-prx-vpc-flow-log-s3.tf#L1-L10
+- **[ERROR]** **[aws-s3-encryption-customer-key]** [[HELP LINK](https://aquasecurity.github.io/tfsec/v1.26.3/checks/aws/s3/encryption-customer-key/)] `Bucket does not encrypt data with a customer managed key.`
+    - https://github.com/owner/repo/blob/master/base/lm-prx-vpc-flow-log-s3.tf#L12-L19
+- **[ERROR]** **[aws-s3-ignore-public-acls]** [[HELP LINK](https://aquasecurity.github.io/tfsec/v1.26.3/checks/aws/s3/ignore-public-acls/)] `No public access block so not ignoring public acls`
+    - https://github.com/owner/repo/blob/master/base/lm-prx-vpc-flow-log-s3.tf#L1-L10
+- **[ERROR]** **[aws-s3-no-public-buckets]** [[HELP LINK](https://aquasecurity.github.io/tfsec/v1.26.3/checks/aws/s3/no-public-buckets/)] `No public access block so not restricting public buckets`
+    - https://github.com/owner/repo/blob/master/base/lm-prx-vpc-flow-log-s3.tf#L1-L10
+- **[NOTE]** **[aws-s3-specify-public-access-block]** [[HELP LINK](https://aquasecurity.github.io/tfsec/v1.26.3/checks/aws/s3/specify-public-access-block/)] `Bucket does not have a corresponding public access block.`
+    - https://github.com/owner/repo/blob/master/base/lm-prx-vpc-flow-log-s3.tf#L1-L10
+- **[ERROR]** **[aws-vpc-no-public-egress-sgr]** [[HELP LINK](https://aquasecurity.github.io/tfsec/v1.26.3/checks/aws/vpc/no-public-egress-sgr/)] `Security group rule allows egress to multiple public internet addresses.`
+    - https://github.com/owner/repo/blob/master/base/lm-prx-sg.tf#L34-L34
+- **[ERROR]** **[aws-vpc-no-public-ingress-sgr]** [[HELP LINK](https://aquasecurity.github.io/tfsec/v1.26.3/checks/aws/vpc/no-public-ingress-sgr/)] `Security group rule allows ingress from public internet.`
+    - https://github.com/owner/repo/blob/master/base/lm-prx-sg.tf#L18-L18
+
+
+
+## Suppressed Results
+
+Nothing here.
+
+
+
+## Rules information
+<!-- Rule Info -->
+<details><summary>Rules details</summary>
+
+
+    - aws-cloudwatch-log-group-customer-key [] 
+
+    > CloudWatch log groups should be encrypted using CMK
+,
+
+    - aws-ec2-enable-at-rest-encryption [] 
+
+    > Instance with unencrypted block device.
+,
+
+    - aws-ec2-enforce-http-token-imds [] 
+
+    > aws_instance should activate session tokens for Instance Metadata Service.
+,
+
+    - aws-ecs-enable-container-insight [] 
+
+    > ECS clusters should have container insights enabled
+,
+
+    - aws-iam-no-policy-wildcards [] 
+
+    > IAM policy should avoid use of wildcards and instead apply the principle of least privilege
+,
+
+    - aws-s3-block-public-acls [] 
+
+    > S3 Access block should block public ACL
+,
+
+    - aws-s3-block-public-policy [] 
+
+    > S3 Access block should block public policy
+,
+
+    - aws-s3-enable-bucket-logging [] 
+
+    > S3 Bucket does not have logging enabled.
+,
+
+    - aws-s3-encryption-customer-key [] 
+
+    > S3 encryption should use Customer Managed Keys
+,
+
+    - aws-s3-ignore-public-acls [] 
+
+    > S3 Access Block should Ignore Public Acl
+,
+
+    - aws-s3-no-public-buckets [] 
+
+    > S3 Access block should restrict public bucket to limit access
+,
+
+    - aws-s3-specify-public-access-block [] 
+
+    > S3 buckets should each define an aws_s3_bucket_public_access_block
+,
+
+    - aws-vpc-no-public-egress-sgr [] 
+
+    > An egress security group rule allows traffic to /0.
+,
+
+    - aws-vpc-no-public-ingress-sgr [] 
+
+    > An ingress security group rule allows traffic from /0.
+
+
+## Tool information
+- Name: tfsec
+- Organization: undefined
+- Version: undefined


### PR DESCRIPTION
Fixes #50 

Refactored the original implementation a bit to reduce code duplication in `createGroupedResultsMarkdown` and `createGroupedSuppressedResultsMarkdown`