### PR TITLE
fix(docs): Wrong cli doc for --severity in comment

### DIFF
--- a/packages/sarif-to-comment/README.md
+++ b/packages/sarif-to-comment/README.md
@@ -28,7 +28,7 @@ Install with [npm](https://www.npmjs.com/):
       --action                      Authentication mode for the token, defaults to PAT, if set, switches to Github Action
       --ruleDetails                 Include full JSON rule details in the markdown, might be too big for Github's API, defaults to false
       --simple                      Simplify the output to only give findings grouped by rule, adds helpURI if present
-      --severity                    Filter output issues by their severity level, warning, error, note, none (separated by commas)
+      --severity                    Filter output issues by their severity level, warning, error, note, none, set flag for each level      
       --failon                      Throw an exit error code 1 if an issue with that level was detected, warning, error, note, none, or all, set flag for each, NOT affected by severity filtering
       --commentUrl                  Post to comment URL. e.g. https://github.com/owner/repo/issues/85
       --title                       Specify a comment title for the report, optional


### PR DESCRIPTION
That has not been updated, so npm is not showing the actual cli flags, it's the old one (which was comma-separated and not multi-flag)