### PR TITLE
fix: missing close tag for details

### DIFF
--- a/packages/sarif-to-markdown/src/sarif-to-markdown.ts
+++ b/packages/sarif-to-markdown/src/sarif-to-markdown.ts
@@ -25,7 +25,7 @@ ${run.tool.driver?.rules?.map((rule: any) => {
     return `\n
     - ${rule.id} [${severity}] \n
     > ${rule.shortDescription?.text}\n`;
-})}`;
+})}</details>`;
 }
 
 function createToolInfo(run: Run) {


### PR DESCRIPTION
Issue: markdown parser missing close tag for details.

Bug POC, please see https://github.com/codeql-agent-project/codeql-agent-cli/issues/7 where the first details section hides the rest of the report.