### PR TITLE
Check whether suppression's are an empty array or not, after checking whether undefined

### DIFF
--- a/packages/sarif-to-markdown/src/sarif-to-markdown.ts
+++ b/packages/sarif-to-markdown/src/sarif-to-markdown.ts
@@ -158,7 +158,7 @@ function createGroupedResultsMarkdown(groupedResults: any, run: any, options: sa
             }\`` + "\n";
         for (const result of groupedResults[rule]) {
             const properResult = result as unknown as Result;
-            if (properResult.suppressions === undefined) {
+            if (properResult.suppressions === undefined || (Array.isArray(properResult.suppressions) && properResult.suppressions.length === 0)) {
                 groupedResultsMarkdown += "    - " + createCodeURL(result, options) + "\n";
             }
         }
@@ -187,8 +187,11 @@ function createGroupedSuppressedResultsMarkdown(groupedResults: any, run: any, o
             for (const result of groupedResults[rule]) {
                 const properResult = result as unknown as Result;
                 if (properResult.suppressions !== undefined) {
-                    suppressedCounter += 1;
-                    groupedSuppressedResultsMD += "    - " + createCodeURL(result, options) + "\n";
+                    //Typescript isn't liking checking Array.isArray as an OR clause in the array, so let's do it here
+                    if (properResult.suppressions.length > 0) {
+                        suppressedCounter += 1;
+                        groupedSuppressedResultsMD += "    - " + createCodeURL(result, options) + "\n";
+                    }
                 }
             }
         }

--- a/packages/sarif-to-markdown/test/snapshote.test.ts
+++ b/packages/sarif-to-markdown/test/snapshote.test.ts
@@ -33,13 +33,12 @@ describe("Snapshot testing", () => {
             }
             // compare input and output
             const expectedContent = fs.readFileSync(expectedFilePath, "utf-8");
+            assert.strictEqual(actualResultsMd, expectedContent);
+
             // compare special hasMessages variable for a test case
             if (normalizedTestName === "simple semgrep juiceshop error only empty") {
-                assert.strictEqual(actualResultsMd, expectedContent);
                 assert.strictEqual(actualResults[0].hasMessages, false);
-            }
-            if (normalizedTestName === "simple semgrep juiceshop throw fail") {
-                assert.strictEqual(actualResultsMd, expectedContent);
+            } else if (normalizedTestName === "simple semgrep juiceshop throw fail") {
                 assert.strictEqual(actualResults[0].hasMessages, true);
                 assert.strictEqual(actualResults[0].shouldFail, true);
             }

--- a/packages/sarif-to-markdown/test/snapshots/hidden-details/output.md
+++ b/packages/sarif-to-markdown/test/snapshots/hidden-details/output.md
@@ -22,7 +22,7 @@
     - js/xss [error] 
 
     > Client-side cross-site scripting
-
+</details>
 
 ## Tool information
 - Name: CodeQL command-line toolchain

--- a/packages/sarif-to-markdown/test/snapshots/multiple-results/output.md
+++ b/packages/sarif-to-markdown/test/snapshots/multiple-results/output.md
@@ -21,7 +21,7 @@ Nothing here.
     - js/xss [error] 
 
     > Client-side cross-site scripting
-
+</details>
 
 ## Tool information
 - Name: CodeQL command-line toolchain

--- a/packages/sarif-to-markdown/test/snapshots/no-findings/output.md
+++ b/packages/sarif-to-markdown/test/snapshots/no-findings/output.md
@@ -20,7 +20,7 @@ Nothing here.
     - js/xss [error] 
 
     > Client-side cross-site scripting
-
+</details>
 
 ## Tool information
 - Name: CodeQL command-line toolchain

--- a/packages/sarif-to-markdown/test/snapshots/no-suppressed-finding/output.md
+++ b/packages/sarif-to-markdown/test/snapshots/no-suppressed-finding/output.md
@@ -16,7 +16,7 @@
     - js/xss [error] 
 
     > Client-side cross-site scripting
-
+</details>
 
 ## Tool information
 - Name: CodeQL command-line toolchain

--- a/packages/sarif-to-markdown/test/snapshots/semgrep-juiceshop/output.md
+++ b/packages/sarif-to-markdown/test/snapshots/semgrep-juiceshop/output.md
@@ -1061,7 +1061,7 @@
     - python.docker.security.audit.docker-arbitrary-container-run.docker-arbitrary-container-run [undefined] 
 
     > If unverified user data can reach the `run` or `create` method it can result in running arbitrary container.
-
+</details>
 
 ## Tool information
 - Name: semgrep

--- a/packages/sarif-to-markdown/test/snapshots/shown-details/output.md
+++ b/packages/sarif-to-markdown/test/snapshots/shown-details/output.md
@@ -22,7 +22,7 @@
     - js/xss [error] 
 
     > Client-side cross-site scripting
-
+</details>
 <details><summary>Details</summary>
 <pre>{
     "driver": {

--- a/packages/sarif-to-markdown/test/snapshots/suppressed-finding/input.json
+++ b/packages/sarif-to-markdown/test/snapshots/suppressed-finding/input.json
@@ -899,7 +899,8 @@
                 "text": "user-provided value"
               }
             }
-          ]
+          ],
+          "suppressions": []
         }
       ],
       "newlineSequences": [

--- a/packages/sarif-to-markdown/test/snapshots/suppressed-finding/output.md
+++ b/packages/sarif-to-markdown/test/snapshots/suppressed-finding/output.md
@@ -24,7 +24,7 @@
     - js/xss [error] 
 
     > Client-side cross-site scripting
-
+</details>
 
 ## Tool information
 - Name: CodeQL command-line toolchain

--- a/packages/sarif-to-markdown/test/snapshots/title-example/output.md
+++ b/packages/sarif-to-markdown/test/snapshots/title-example/output.md
@@ -21,7 +21,7 @@
     - js/xss [error] 
 
     > Client-side cross-site scripting
-
+</details>
 
 ## Tool information
 - Name: CodeQL command-line toolchain

--- a/packages/sarif-to-markdown/test/snapshots/xss/output.md
+++ b/packages/sarif-to-markdown/test/snapshots/xss/output.md
@@ -22,7 +22,7 @@
     - js/xss [error] 
 
     > Client-side cross-site scripting
-
+</details>
 
 ## Tool information
 - Name: CodeQL command-line toolchain


### PR DESCRIPTION
While using this project in github actions for another repository I noticed that results (grouped by rule) can all be grouped into suppressions even if only one of the results had a real suppression.

Example:
In this situation the file `src/jobs/update_podcasts.js` has 3 console.log statements and only the one on line 25 had a suppression with eslint as `eslint-disable-next-line no-console -- Debugging`. The SARIF file was generated by [@microsoft/eslint-formatter-sarif](https://github.com/Microsoft/sarif-js-sdk) though I don't believe that matters, apart from the fact it outputs suppressions as an empty array rather than leaving that property off.
![image](https://github.com/user-attachments/assets/250b1558-1c88-4b58-b7f2-6d7379e6132a)

Then when working on a fix the first thing I noticed was the tests all passing even as I changed the code. That lead me to finding https://github.com/security-alert/security-alert/commit/11f9a96ca094ab62e63d460a89e40ea6e040b5a0#diff-50f230eec4a2d5dd798fd3c89a0d9d0c4a06244ad3c346dc3269d294c91d05b4L36 that the content assertion was unintentionally moved so it only ran for special cases tests, rather than for all. This seemingly was easily missed because mocha reports the test as passed and unlike other test runners does not print how many assertions there were, as seeing zero would have clued you to it. 

For the fix itself per https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790911 the result object MAY contain a suppressions property, and if it exists it must be an array of **zero or more unique** suppression objects. The code was assuming that if the property was present it contained a non-empty array which doesn't match the spec.